### PR TITLE
Fix GNOME Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official Radare Iaito Flatpak package.
 
 ## Permissions
 
-- GUI: `wayland`, X11 (`ipc` + `fallback-x11`).
+- GUI: `wayland`, X11 (`ipc` + `fallback-x11`), dri.
 
 ## Special configurations
 

--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -7,6 +7,7 @@ sdk: org.kde.Sdk
 command: iaito
 finish-args:
   - --share=ipc
+  - --device=dri
   - --socket=wayland
   - --socket=fallback-x11
 


### PR DESCRIPTION
Gnome wayland is failing to display window border because it needs EGL.

Revert remove dri permission (4e10e95ce7f32ee403f322f6c7e0eb41c7e443ec).