### PR TITLE
Change runtime to qt 5.15

### DIFF
--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -1,7 +1,7 @@
 app-id: org.radare.iaito
 
 runtime: org.kde.Platform
-runtime-version: '6.4'
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 
 command: iaito


### PR DESCRIPTION
iaito is crashing with qt6, reverting to use qt 5.15.

Reverts flathub/org.radare.iaito#31