### PR TITLE
Remove r2dec plugin temporally

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ List of project URLs of the modules included in this flatpak version of iaito wi
 - [radare2](https://github.com/radareorg/radare2)
   - [r2ghidra](https://github.com/radareorg/r2ghidra)
   - [r2frida](https://github.com/nowsecure/r2frida)
-  - [r2dec](https://github.com/wargio/r2dec-js)
   - [r2yara](https://github.com/radareorg/r2yara)
   - [r2ai](https://github.com/radareorg/r2ai) (only decai r2plugin)
   - [r2pipe](https://github.com/radareorg/radare2-r2pipe) (only python)

--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -139,29 +139,6 @@ modules:
             mkdir -vp "${FRIDA_DEST}" && tar -vxJf frida-core-devkit-*.tar.xz -C "${FRIDA_DEST}"
           - rm -vf frida-core-devkit-*.tar.xz
 
-  - name: r2dec
-    buildsystem: meson
-    build-options:
-      cflags: -O3
-    sources:
-      - type: git
-        url: https://github.com/wargio/r2dec-js.git
-        tag: 5.9.4
-        commit: 53760c664b7497d6e558ab7e6aa7040f748cd43d
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/wargio/r2dec-js/releases/latest
-          timestamp-query: .published_at
-          version-query: .tag_name
-          tag-query: .tag_name
-      - type: git
-        url: https://github.com/frida/quickjs.git
-        commit: c81f05c9859cea5f83a80057416a0c7affe9b876
-        dest: subprojects/libquickjs
-      - type: shell
-        commands:
-          - meson subprojects packagefiles --apply
-
   - name: r2yara
     buildsystem: autotools
     build-options:


### PR DESCRIPTION
After waiting a upstream fix for #98.

We have decided to remove temporally r2dec.