### PR TITLE
Add C-R2AI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ List of project URLs of the modules included in this flatpak version of iaito wi
   - [r2frida](https://github.com/nowsecure/r2frida)
   - [r2dec](https://github.com/wargio/r2dec-js)
   - [r2yara](https://github.com/radareorg/r2yara)
-  - [r2ai](https://github.com/radareorg/r2ai) (only decai r2plugin)
+  - [r2ai](https://github.com/radareorg/r2ai)
   - [r2pipe](https://github.com/radareorg/radare2-r2pipe) (only python)

--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -191,8 +191,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/radareorg/r2ai.git
-        tag: 0.9.4
-        commit: 094fc325c55d26b2933deae4fba90cff824be563
+        tag: 0.9.6
+        commit: 733ebf9283e590f69967f9e240753464bca330a3
         x-checker-data:
           type: json
           url: https://api.github.com/repos/radareorg/r2ai/releases/latest

--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -184,9 +184,11 @@ modules:
             commands:
               - ./bootstrap.sh
 
-  - name: r2ai-decai
+  - name: r2ai
     buildsystem: simple
     build-commands:
+      - make -C src
+      - make -C src install
       - make -C decai install
     sources:
       - type: git


### PR DESCRIPTION
- Update r2ai to 0.9.6
- Add [C-R2AI plugin](https://github.com/radareorg/r2ai/blob/0.9.6/src/README.md)