### PR TITLE
Disable iaito debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Official Radare Iaito Flatpak package.
 The required permissions for GUI are: `wayland`, X11 (`ipc` + `fallback-x11`), `dri`.
 Also to allow ptrace in radare2: `devel`.
 
+### Enable optional Web UI
+
+By default neither the web component nor the network permissions are enabled, if you want to be able to start the web UI from menu `Edit > Start web server` you need to run this commands:
+
+```sh
+flatpak install --user org.radare.iaito.webui
+flatpak override --user --share=network org.radare.iaito
+```
 
 ### Optional permissions
 
@@ -44,20 +52,27 @@ To do so one need to define the following aliases:
 ```sh
 alias r2='flatpak run --command=r2 org.radare.iaito'
 alias r2agent='flatpak run --command=r2agent org.radare.iaito'
+alias r2frida-compile='flatpak run --command=r2frida-compile org.radare.iaito'
 alias r2p='flatpak run --command=r2p org.radare.iaito'
 alias r2pm='flatpak run --command=r2pm --share=network --devel org.radare.iaito'
 alias r2r='flatpak run --command=r2r org.radare.iaito'
+alias r2sdb='flatpak run --command=r2sdb org.radare.iaito'
 alias rabin2='flatpak run --command=rabin2 org.radare.iaito'
 alias radare2='flatpak run --command=radare2 org.radare.iaito'
 alias radiff2='flatpak run --command=radiff2 org.radare.iaito'
 alias rafind2='flatpak run --command=rafind2 org.radare.iaito'
+alias rafs2='flatpak run --command=rafs2 org.radare.iaito'
 alias ragg2='flatpak run --command=ragg2 org.radare.iaito'
 alias rahash2='flatpak run --command=rahash2 org.radare.iaito'
+alias rapatch2='flatpak run --command=rapatch2 org.radare.iaito'
 alias rarun2='flatpak run --command=rarun2 org.radare.iaito'
 alias rasign2='flatpak run --command=rasign2 org.radare.iaito'
 alias rasm2='flatpak run --command=rasm2 org.radare.iaito'
 alias ravc2='flatpak run --command=ravc2 org.radare.iaito'
 alias rax2='flatpak run --command=rax2 org.radare.iaito'
+alias sleighc='flatpak run --command=sleighc org.radare.iaito'
+alias yara='flatpak run --command=yara org.radare.iaito'
+alias yarac='flatpak run --command=yarac org.radare.iaito'
 ```
 
 With this commands, by default no local files will be accesible.

--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -233,6 +233,7 @@ modules:
     config-opts:
       - -config
       - release
+      - IAITO_ENABLE_DEBUGGER=false
     subdir: src
     sources:
       - type: git


### PR DESCRIPTION
New feature to allow to attach to process, doesn't make sense in flatpak since it doesn't have visibility on processes outside the namespace.

So we proceed to disable for this builds.