### PR TITLE
Update to QT 6.11

### DIFF
--- a/org.radare.iaito.yaml
+++ b/org.radare.iaito.yaml
@@ -1,7 +1,7 @@
 app-id: org.radare.iaito
 
 runtime: org.kde.Platform
-runtime-version: 6.10
+runtime-version: 6.11
 sdk: org.kde.Sdk
 
 command: iaito


### PR DESCRIPTION
Last PR rised a warning due the use of deprecated runtime.

> ⚠️  Linter warnings:
> 
> _Warnings can be promoted to errors in the future. Please try to resolve them._
> 
> - 'runtime-update-available-to-org.kde.Platform-6.11' warning found in linter manifest check. Details: Please consider updating to the latest runtime version